### PR TITLE
Updating .gitignore file. Ingoring CMake resources.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,12 @@
 .github
 .devcontainer
 
+**/out
+
 *.exe
 *.o
 *.i
 *.s
+
+**/CMakeLists.txt
+**/CMakePresets.json


### PR DESCRIPTION
# Ingoring CMake resources
With this PR, now we're avoiding to commit every resource that CMake needs to propertly work. This includes:
- `**/out`: main resources to allow CMake work in the directory.
- `**/CMakeLists.txt`: Options/commands to use CMake.
- `**/CMakePresets.json`: Local config file to allow CMake to run in machine.